### PR TITLE
Fix kitty font after exiting Neovide

### DIFF
--- a/lua/custom/plugins/zen-mode.lua
+++ b/lua/custom/plugins/zen-mode.lua
@@ -70,7 +70,9 @@ return {
           vim.fn.jobstart { 'kitty', '@', 'set-font-size', '+2' }
         end
       else
-        vim.fn.jobstart { 'kitty', '@', 'set-font-size', '+2' }
+        if not vim.g.neovide then
+          vim.fn.jobstart { 'kitty', '@', 'set-font-size', '+2' }
+        end
       end
     end,
 


### PR DESCRIPTION
## Summary
- avoid running kitty font resize commands if Neovide is active

## Testing
- `stylua lua/custom/plugins/zen-mode.lua`


------
https://chatgpt.com/codex/tasks/task_e_6843b9c245f0832889993fad0c26baf1