### PR TITLE
Hide Neovide statusline at startup

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -93,6 +93,11 @@ vim.g.maplocalleader = ' '
 -- Set to true if you have a Nerd Font installed and selected in the terminal
 vim.g.have_nerd_font = false
 
+-- Hide the statusline when running inside Neovide
+if vim.g.neovide then
+  vim.opt.laststatus = 0
+end
+
 -- [[ Setting options ]]
 require 'options'
 


### PR DESCRIPTION
## Summary
- hide the statusline when launching Neovide

## Testing
- `nvim --headless --cmd 'let g:neovide=1' -u init.lua +'echo &laststatus' +q` *(fails: `nvim` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68446a715f98832887f46fc45c6ffa35