### PR TITLE
Add missing colorscheme plugins

### DIFF
--- a/lua/custom/plugins/catppuccin.lua
+++ b/lua/custom/plugins/catppuccin.lua
@@ -1,0 +1,7 @@
+-- Adds the Catppuccin colorscheme for the colorscheme selector
+return {
+  'catppuccin/nvim',
+  name = 'catppuccin',
+  lazy = false,
+  priority = 1000,
+}

--- a/lua/custom/plugins/everforest.lua
+++ b/lua/custom/plugins/everforest.lua
@@ -1,0 +1,6 @@
+-- Adds the Everforest colorscheme for the colorscheme selector
+return {
+  'sainnhe/everforest',
+  lazy = false,
+  priority = 1000,
+}

--- a/lua/custom/plugins/kanagawa.lua
+++ b/lua/custom/plugins/kanagawa.lua
@@ -1,0 +1,6 @@
+-- Adds the Kanagawa colorscheme for the colorscheme selector
+return {
+  'rebelot/kanagawa.nvim',
+  lazy = false,
+  priority = 1000,
+}

--- a/lua/custom/plugins/monokai-pro.lua
+++ b/lua/custom/plugins/monokai-pro.lua
@@ -1,0 +1,6 @@
+-- Adds the Monokai Pro colorscheme for the colorscheme selector
+return {
+  'loctvl842/monokai-pro.nvim',
+  lazy = false,
+  priority = 1000,
+}

--- a/lua/custom/plugins/rose-pine.lua
+++ b/lua/custom/plugins/rose-pine.lua
@@ -1,0 +1,7 @@
+-- Adds the Rose Pine colorscheme for the colorscheme selector
+return {
+  'rose-pine/neovim',
+  name = 'rose-pine',
+  lazy = false,
+  priority = 1000,
+}


### PR DESCRIPTION
## Summary
- add Everforest, Catppuccin, Rose Pine, Kanagawa and Monokai Pro colorscheme plugins

## Testing
- `nvim --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ad7f247e483288f34ce4469520549